### PR TITLE
heapq is part of the python lib

### DIFF
--- a/python_actr/scheduler.py
+++ b/python_actr/scheduler.py
@@ -1,8 +1,5 @@
 
-try:
-    import heapq
-except ImportError:
-    import ccm.legacy.heapq as heapq
+import heapq
 import copy
 
 from . import logger


### PR DESCRIPTION
The old ccm legacy code does not exist anymore, and heapq is just part of python, so remove this try/except.