### PR TITLE
Add python version requirement to pip setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import python_actr
 
 setup(
     name='python_actr',
+    python_requires='>=3.0,<3.11',
     packages=['python_actr', 'python_actr.display', 'python_actr.actr', 'python_actr.ui'],
     version=python_actr.version.version,
     author='Carleton Cognitive Modelling Lab',


### PR DESCRIPTION
Until python_actr is updated for 3.11, pip should prevent installation on 3.11.