### PR TITLE
Python 3.11 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Python ACT-R
 A Python implementation of the ACT-R cognitive Architecture
 
-Please note that this version of Python ACT-R does not run on Python 3.11 or higher
+Please note that this version of Python ACT-R does not run on Python 3.12 or higher
 
 Install Python ACT-R from the command line using either `pip` or `pip3` as follows:
 

--- a/python_actr/production.py
+++ b/python_actr/production.py
@@ -59,7 +59,7 @@ class ProductionSystem(model.Model):
         self._initializers=[]
         self._keys_used=Set()
         for k,v in list(methods.items()):
-            a,va,hk,dd,kwa,kwd,ant=inspect.getfullargspec(v)
+            a,va,hk,d,kwa,kwd,ant=inspect.getfullargspec(v)
             if va is None and hk is None:
               if d is None and len(a)==0:
                 p=Production(self,k,v)

--- a/python_actr/production.py
+++ b/python_actr/production.py
@@ -13,28 +13,13 @@ except:
 class ProductionException(Exception):
     pass
 
-class Inspect:
-        @staticmethod
-        def monkeypatch():
-            import inspect
-            print('Applying monkeypatch for inspect')
-            if hasattr(inspect, 'getfullargspec') and not hasattr(inspect, 'getargspec'):
-                def getargspec(func):
-                    from collections import namedtuple
-                    inspect_result = inspect.getfullargspec(func)
-                    ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
-                    return ArgSpec(
-                        inspect_result.args, inspect_result.varargs,
-                        inspect_result.varkw, inspect_result.defaults
-                    )
-                inspect.getargspec = getargspec
 
 class Production:
     def __init__(self,system,name,func):
         self.system=system
         self.name=name
         self.base_utility=0
-        a,va,hk,d=inspect.getargspec(func)
+        a,va,hk,d,kwa,kwd,ant =inspect.getfullargspec(func)
         self.keys=a
         patterns={}
         for i,name in enumerate(a[:]):
@@ -74,7 +59,7 @@ class ProductionSystem(model.Model):
         self._initializers=[]
         self._keys_used=Set()
         for k,v in list(methods.items()):
-            a,va,hk,d=inspect.getargspec(v)
+            a,va,hk,dd,kwa,kwd,ant=inspect.getfullargspec(v)
             if va is None and hk is None:
               if d is None and len(a)==0:
                 p=Production(self,k,v)

--- a/python_actr/production.py
+++ b/python_actr/production.py
@@ -18,7 +18,7 @@ class Production:
         self.system=system
         self.name=name
         self.base_utility=0
-        a,va,hk,d=inspect.getfullargspec(func)
+        a,va,hk,d=inspect.signature(func)
         self.keys=a
         patterns={}
         for i,name in enumerate(a[:]):
@@ -58,7 +58,7 @@ class ProductionSystem(model.Model):
         self._initializers=[]
         self._keys_used=Set()
         for k,v in list(methods.items()):
-            a,va,hk,d=inspect.getfullargspec(v)
+            a,va,hk,d=inspect.signature(v)
             if va is None and hk is None:
               if d is None and len(a)==0:
                 p=Production(self,k,v)

--- a/python_actr/production.py
+++ b/python_actr/production.py
@@ -18,7 +18,7 @@ class Production:
         self.system=system
         self.name=name
         self.base_utility=0
-        a,va,hk,d=inspect.getargspec(func)
+        a,va,hk,d=inspect.getfullargspec(func)
         self.keys=a
         patterns={}
         for i,name in enumerate(a[:]):
@@ -58,7 +58,7 @@ class ProductionSystem(model.Model):
         self._initializers=[]
         self._keys_used=Set()
         for k,v in list(methods.items()):
-            a,va,hk,d=inspect.getargspec(v)
+            a,va,hk,d=inspect.getfullargspec(v)
             if va is None and hk is None:
               if d is None and len(a)==0:
                 p=Production(self,k,v)

--- a/python_actr/production.py
+++ b/python_actr/production.py
@@ -13,12 +13,28 @@ except:
 class ProductionException(Exception):
     pass
 
+class Inspect:
+        @staticmethod
+        def monkeypatch():
+            import inspect
+            print('Applying monkeypatch for inspect')
+            if hasattr(inspect, 'getfullargspec') and not hasattr(inspect, 'getargspec'):
+                def getargspec(func):
+                    from collections import namedtuple
+                    inspect_result = inspect.getfullargspec(func)
+                    ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
+                    return ArgSpec(
+                        inspect_result.args, inspect_result.varargs,
+                        inspect_result.varkw, inspect_result.defaults
+                    )
+                inspect.getargspec = getargspec
+
 class Production:
     def __init__(self,system,name,func):
         self.system=system
         self.name=name
         self.base_utility=0
-        a,va,hk,d=inspect.signature(func)
+        a,va,hk,d=inspect.getargspec(func)
         self.keys=a
         patterns={}
         for i,name in enumerate(a[:]):
@@ -58,7 +74,7 @@ class ProductionSystem(model.Model):
         self._initializers=[]
         self._keys_used=Set()
         for k,v in list(methods.items()):
-            a,va,hk,d=inspect.signature(v)
+            a,va,hk,d=inspect.getargspec(v)
             if va is None and hk is None:
               if d is None and len(a)==0:
                 p=Production(self,k,v)


### PR DESCRIPTION
- updated inspect.getargspec calls to inspect.getfullsrgspec 
- now python act-r works with python 3.11